### PR TITLE
Added AMD support

### DIFF
--- a/knockout-file-bind.js
+++ b/knockout-file-bind.js
@@ -21,67 +21,78 @@
  *   reader: an existing FileReader object. If not defined, creates a new
  *     one internally.
  */
+ 
+(function () {
+  var factory = function (ko) {
 
-ko.bindingHandlers['file'] = {
-  init: function(element, valueAccessor, allBindings) {
-    var fileContents, fileName, allowed, prohibited, reader;
-
-    if ((typeof valueAccessor()) === "function") {
-      fileContents = valueAccessor();
-    } else {
-      fileContents = valueAccessor()['data'];
-      fileName = valueAccessor()['name'];
-
-      allowed = valueAccessor()['allowed'];
-      if ((typeof allowed) === 'string') {
-        allowed = [allowed];
-      }
-
-      prohibited = valueAccessor()['prohibited'];
-      if ((typeof prohibited) === 'string') {
-        prohibited = [prohibited];
-      }
-
-      reader = (valueAccessor()['reader']);
-    }
-
-    reader || (reader = new FileReader());
-    reader.onloadend = function() {
-      fileContents(reader.result);
-    }
-
-    var handler = function() {
-      var file = element.files[0];
-
-      // Opening the file picker then canceling will trigger a 'change'
-      // event without actually picking a file.
-      if (file === undefined) {
-        fileContents(null)
-        return;
-      }
-
-      if (allowed) {
-        if (!allowed.some(function(type) { return type === file.type })) {
-          console.log("File "+file.name+" is not an allowed type, ignoring.")
-          fileContents(null)
-          return;
+    ko.bindingHandlers['file'] = {
+      init: function(element, valueAccessor, allBindings) {
+        var fileContents, fileName, allowed, prohibited, reader;
+    
+        if ((typeof valueAccessor()) === "function") {
+          fileContents = valueAccessor();
+        } else {
+          fileContents = valueAccessor()['data'];
+          fileName = valueAccessor()['name'];
+    
+          allowed = valueAccessor()['allowed'];
+          if ((typeof allowed) === 'string') {
+            allowed = [allowed];
+          }
+    
+          prohibited = valueAccessor()['prohibited'];
+          if ((typeof prohibited) === 'string') {
+            prohibited = [prohibited];
+          }
+    
+          reader = (valueAccessor()['reader']);
         }
-      }
-
-      if (prohibited) {
-        if (prohibited.some(function(type) { return type === file.type })) {
-          console.log("File "+file.name+" is a prohibited type, ignoring.")
-          fileContents(null)
-          return;
+    
+        reader || (reader = new FileReader());
+        reader.onloadend = function() {
+          fileContents(reader.result);
         }
-      }
-
-      reader.readAsDataURL(file); // A callback (above) will set fileContents
-      if (typeof fileName === "function") {
-        fileName(file.name)
+    
+        var handler = function() {
+          var file = element.files[0];
+    
+          // Opening the file picker then canceling will trigger a 'change'
+          // event without actually picking a file.
+          if (file === undefined) {
+            fileContents(null)
+            return;
+          }
+    
+          if (allowed) {
+            if (!allowed.some(function(type) { return type === file.type })) {
+              console.log("File "+file.name+" is not an allowed type, ignoring.")
+              fileContents(null)
+              return;
+            }
+          }
+    
+          if (prohibited) {
+            if (prohibited.some(function(type) { return type === file.type })) {
+              console.log("File "+file.name+" is a prohibited type, ignoring.")
+              fileContents(null)
+              return;
+            }
+          }
+    
+          reader.readAsDataURL(file); // A callback (above) will set fileContents
+          if (typeof fileName === "function") {
+            fileName(file.name)
+          }
+        }
+    
+        ko.utils.registerEventHandler(element, 'change', handler);
       }
     }
-
-    ko.utils.registerEventHandler(element, 'change', handler);
   }
-}
+
+  if (define) {
+    define(['knockout'], factory);
+  } else {
+    factory(ko);
+  }
+})();

--- a/knockout-file-bind.js
+++ b/knockout-file-bind.js
@@ -89,8 +89,8 @@
       }
     }
   }
-
-  if (define) {
+  
+  if (define && typeof define === 'function' && define.amd)
     define(['knockout'], factory);
   } else {
     factory(ko);

--- a/knockout-file-bind.js
+++ b/knockout-file-bind.js
@@ -90,7 +90,7 @@
     }
   }
   
-  if (define && typeof define === 'function' && define.amd)
+  if (define && (typeof define === 'function') && define.amd)
     define(['knockout'], factory);
   } else {
     factory(ko);


### PR DESCRIPTION
Added AMD support - now the library can be used with requirejs or other AMD js library.  This is useful, as when knockout is referenced with requirejs, for example, it is not necessary for it to expose the global `ko` variable. It's absence however causes this script to fail.

The submitted fix would assume that if an AMD library is used, the knockout dependency is named "knockout" - which is already a standard among a number of knockout-related modules I have worked with (for example [knockout-amd-helpers](https://github.com/rniemeyer/knockout-amd-helpers) ).

If no AMD is available, the library will rely on the global `ko` object exposed by the knockout.js library if directly referenced by a script tag, which it currently does.
